### PR TITLE
Updated Redshift JDBC driver version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
       <dependency>
         <groupId>com.amazon.redshift</groupId>
         <artifactId>redshift-jdbc4-no-awssdk</artifactId>
-        <version>1.2.8.1005</version>
+        <version>1.2.10.1009</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Using the older version causes the error below on Redshift with certain queries, for instance, when you try to generate a Cohort.

[Amazon][JDBC](10040) Cannot use commit while Connection is in auto-commit mode.